### PR TITLE
Handle single gender breeding logic

### DIFF
--- a/src/pokemon/PokemonBuilder.test.ts
+++ b/src/pokemon/PokemonBuilder.test.ts
@@ -5,6 +5,17 @@
  */
 
 import { IVBuilder } from "@pokemmo/pokemon/IVUtils";
+jest.mock("@pokemmo/data/pokedex", () => {
+    const data: Record<string, any> = {
+        tauros: { identifier: "tauros", eggGroup1: "Field", percentageMale: 100 },
+        chansey: { identifier: "chansey", eggGroup1: "Fairy", percentageMale: 0 },
+        magnemite: { identifier: "magnemite", eggGroup1: "Genderless", percentageMale: 0 },
+        deino: { identifier: "deino", eggGroup1: "Dragon", percentageMale: 50 },
+        main: { identifier: "main", eggGroup1: "Field", percentageMale: 50 },
+        magikarp: { identifier: "magikarp", eggGroup1: "Water a", percentageMale: 50 },
+    };
+    return { getPokemon: (id: string) => data[id] };
+});
 import { PokemonBuilder } from "@pokemmo/pokemon/PokemonBuilder";
 import { Gender, Stat } from "@pokemmo/pokemon/PokemonTypes";
 
@@ -177,6 +188,26 @@ describe("PokemonBuilder", () => {
             expect(countSpecialAttack).toEqual(2);
             expect(countHP).toEqual(1);
             expect(countDefense).toEqual(1);
+        });
+
+        it("uses Ditto for missing genders", () => {
+            const maleOnly = PokemonBuilder.create("tauros")
+                .ivs(IVBuilder.maxedStats([Stat.HP, Stat.DEFENSE]))
+                .gender(Gender.MALE);
+            const maleParents = maleOnly.calculateBreeders();
+            expect(maleParents[1].allowedIdentifiers).toContain("ditto");
+
+            const femaleOnly = PokemonBuilder.create("chansey")
+                .ivs(IVBuilder.maxedStats([Stat.HP, Stat.DEFENSE]))
+                .gender(Gender.FEMALE);
+            const femaleParents = femaleOnly.calculateBreeders();
+            expect(femaleParents[1].allowedIdentifiers).toContain("ditto");
+
+            const genderless = PokemonBuilder.create("magnemite")
+                .ivs(IVBuilder.maxedStats([Stat.HP, Stat.DEFENSE]))
+                .gender(Gender.MALE);
+            const genderlessParents = genderless.calculateBreeders();
+            expect(genderlessParents[1].allowedIdentifiers).toContain("ditto");
         });
     });
 });

--- a/src/pokemon/PokemonForm.tsx
+++ b/src/pokemon/PokemonForm.tsx
@@ -127,7 +127,9 @@ export function PokemonForm(_props: IProps) {
     const dexMon = getPokemon(form.values.pokemon);
 
     let forceGender: Gender | undefined;
-    if (dexMon?.percentageMale === 100) {
+    if (dexMon?.eggGroup1 === "Genderless") {
+        forceGender = Gender.MALE;
+    } else if (dexMon?.percentageMale === 100) {
         forceGender = Gender.MALE;
     } else if (dexMon?.percentageMale === 0) {
         forceGender = Gender.FEMALE;

--- a/src/pokemon/PokemonSelect.tsx
+++ b/src/pokemon/PokemonSelect.tsx
@@ -64,6 +64,9 @@ export function PokemonSelect(_props: IProps) {
         const { pokedexMon } = option;
 
         if (forceGender != null) {
+            if (pokedexMon.eggGroup1 === "Genderless") {
+                return false;
+            }
             if (
                 pokedexMon.percentageMale === 100 &&
                 forceGender === Gender.FEMALE


### PR DESCRIPTION
## Summary
- add dynamic import for `getPokemon`
- support genderless and single-gender parents in builder
- enforce gender in forms and selects
- mock pokedex in builder tests
- test Ditto usage for one-gender species

## Testing
- `npm test` *(fails: Do not import `@jest/globals` outside of the Jest test environment)*

------
https://chatgpt.com/codex/tasks/task_e_6852be7ece048333909b3828320c8fd5