### PR TITLE
Implement dark mode toggle

### DIFF
--- a/src/help/HelpPage.tsx
+++ b/src/help/HelpPage.tsx
@@ -6,6 +6,7 @@
 
 import { ButtonType, FormButton } from "@pokemmo/form/FormButton";
 import { PageLayout } from "@pokemmo/layout/PageLayout";
+import { DarkModeToggle } from "@pokemmo/layout/DarkModeToggle";
 import React from "react";
 import { clear } from "redux-localstorage-simple";
 
@@ -29,6 +30,7 @@ export function HelpPage() {
                     >
                         Clear All Data
                     </FormButton>
+                    <DarkModeToggle />
                 </div>
             }
         />

--- a/src/layout/DarkModeToggle.tsx
+++ b/src/layout/DarkModeToggle.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+export function DarkModeToggle() {
+    const [dark, setDark] = React.useState(() => {
+        return localStorage.getItem("darkMode") === "true";
+    });
+
+    React.useEffect(() => {
+        document.body.classList.toggle("dark", dark);
+        localStorage.setItem("darkMode", dark ? "true" : "false");
+    }, [dark]);
+
+    return (
+        <button
+            onClick={() => setDark(!dark)}
+            css={{ marginTop: 16 }}
+        >
+            {dark ? "Light Mode" : "Dark Mode"}
+        </button>
+    );
+}

--- a/src/styles/CssReset.tsx
+++ b/src/styles/CssReset.tsx
@@ -33,6 +33,11 @@ export function CssReset() {
                     color: ${colorText.string()};
                     box-sizing: border-box;
                 }
+
+                body.dark {
+                    background: #1e1e1e;
+                    color: #f4f4f4;
+                }
                 *,
                 *:before,
                 *:after {


### PR DESCRIPTION
## Summary
- add simple dark mode with body class
- include toggle button on Help page

## Testing
- `npm test` *(fails: Cannot find module '@jest/globals')*

------
https://chatgpt.com/codex/tasks/task_e_6852f2daf5bc83339b9eb2d6ce9e18cf