### PR TITLE
Enable automatic breeder reuse

### DIFF
--- a/src/projects/BreedingGuide.tsx
+++ b/src/projects/BreedingGuide.tsx
@@ -29,6 +29,7 @@ import {
     BreedingItem,
     helpItemForPair,
     IBreedingPair,
+    pairNeedsBreeding,
 } from "@pokemmo/projects/breedingUtils";
 import { useProject } from "@pokemmo/projects/projectHooks";
 import { useStubActions } from "@pokemmo/projects/stubSlice";
@@ -99,6 +100,11 @@ export function BreedingGuide(props: IProps) {
         ) {
             const malePokemon = pokemonByID[male.attachedPokemonID];
             const femalePokemon = pokemonByID[female.attachedPokemonID];
+
+            if (!pairNeedsBreeding(pair, pokemonByID)) {
+                completePairs.push(pair);
+                return;
+            }
 
             if (
                 malePokemon?.breedStatus === BreedStatus.NONE &&


### PR DESCRIPTION
## Summary
- auto link new/existing Pokémon to all compatible breeder stubs
- add helper to evaluate whether a Pokémon matches a stub
- skip breeding steps if a parent already satisfies the child requirements

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `npx tsc -p tsconfig.json --noEmit` *(fails: many missing module type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6853261a8748833397fbc7a4f1258490